### PR TITLE
BLT-125 Refactor locals and inputs block

### DIFF
--- a/_envcommon/kubernetes.hcl
+++ b/_envcommon/kubernetes.hcl
@@ -7,7 +7,7 @@ locals {
 
   environment_vars         = read_terragrunt_config(find_in_parent_folders("env.hcl"))
   env                      = local.environment_vars.locals.environment
-  zone                     = local.environment_vars.locals.zone
+  zone                     = local.environment_vars.inputs.zone
   kubernetes_instance_type = local.environment_vars.locals.kubernetes_instance_type
 }
 

--- a/_envcommon/nat.hcl
+++ b/_envcommon/nat.hcl
@@ -5,7 +5,6 @@ terraform {
 locals {
   environment_vars = read_terragrunt_config(find_in_parent_folders("env.hcl"))
   env              = local.environment_vars.locals.environment
-  region           = local.environment_vars.locals.region
 }
 
 dependency "network" {
@@ -20,7 +19,6 @@ dependency "network" {
 inputs = {
   name    = "${local.env}-k8s-router"
   network = dependency.network.outputs.network_name
-  region  = local.region
 
   nats = [
     {

--- a/_envcommon/network.hcl
+++ b/_envcommon/network.hcl
@@ -7,7 +7,7 @@ locals {
 
   environment_vars = read_terragrunt_config(find_in_parent_folders("env.hcl"))
   env              = local.environment_vars.locals.environment
-  region           = local.environment_vars.locals.region
+  region           = local.environment_vars.inputs.region
 }
 
 inputs = {

--- a/stage/env.hcl
+++ b/stage/env.hcl
@@ -1,7 +1,9 @@
 locals {
-  environment = "stage"
-  region      = "us-central1"
-  zone        = "us-central1-b"
-
+  environment              = "stage"
   kubernetes_instance_type = "e2-medium"
+}
+
+inputs = {
+  region = "us-central1"
+  zone   = "us-central1-b"
 }

--- a/terragrunt.hcl
+++ b/terragrunt.hcl
@@ -20,12 +20,15 @@ generate "provider" {
   contents  = <<EOF
 provider "google" {
   project     = "softseve-blue-team"
-  region      = "us-central1"
 }
 EOF
 }
 
 inputs = merge(
+  # Merge common inputs such as `region` and `zone`
+  # Note that some modules may require other names for these inputs
+  # E.g., google/network module with concrete `subnet_region` input
+  local.environment_vars.inputs,
   {
     project_id = "softseve-blue-team"
     project    = "softseve-blue-team" # GCP cloud-router specific


### PR DESCRIPTION
Move common environment variables from locals block to the inputs block. Merge inputs at the root level, so the earlier variables will be available in all initialization modules