### PR TITLE
BLT-126 Allow network access to PostgreSQL

### DIFF
--- a/_envcommon/postgresql.hcl
+++ b/_envcommon/postgresql.hcl
@@ -10,7 +10,7 @@ locals {
 }
 
 inputs = {
-  name                   = "${local.env}-postgres"
+  name                   = "${local.env}-postgresql"
   database_version       = "15"
   maintenance_window_day = 7
   enable_default_user    = false

--- a/stage/postgresql/terragrunt.hcl
+++ b/stage/postgresql/terragrunt.hcl
@@ -5,3 +5,14 @@ include "root" {
 include "envcommon" {
   path = "${dirname(find_in_parent_folders())}/_envcommon/postgresql.hcl"
 }
+
+inputs = {
+  ip_configuration = {
+    authorized_networks = [
+      {
+        name  = "allow-from-anywhere"
+        value = "0.0.0.0/0"
+      }
+    ]
+  }
+}


### PR DESCRIPTION
Allow access to PostgreSQL service machine in order to give Ansible ability to configure the instance